### PR TITLE
Remove System.Windows.Forms dependency as ML 0.6.6 kills it off

### DIFF
--- a/BoneSnap.csproj
+++ b/BoneSnap.csproj
@@ -65,9 +65,6 @@
       <Reference Include="System.Drawing.Common">
         <HintPath>References\net6\System.Drawing.Common.dll</HintPath>
       </Reference>
-      <Reference Include="System.Windows.Forms">
-        <HintPath>References\Managed\System.Windows.Forms.dll</HintPath>
-      </Reference>
       <Reference Include="UnityEngine">
         <HintPath>References\Il2CppAssemblies\UnityEngine.dll</HintPath>
       </Reference>

--- a/Screenshotter.cs
+++ b/Screenshotter.cs
@@ -1,7 +1,6 @@
 ﻿using MelonLoader;
 using System.Collections;
 using System.Drawing;
-using System.Windows.Forms;
 using UnityEngine;
 using DateTime = System.DateTime;
 
@@ -44,9 +43,6 @@ namespace BoneSnap
             var filePath = outputPath + $"/{timecode} {_screenshotIndex}.{format}";
             
             File.WriteAllBytes(filePath, bytes);
-            Clipboard.SetImage(
-                (Bitmap)((new ImageConverter()).ConvertFrom(bytes))
-            );
             
             MelonLogger.Msg($"Screenshot saved as {filePath}!");
         }


### PR DESCRIPTION
Capturing logic doesn't work anymore with latest ML because of System.Windows.Forms being killed off
Can't throw it into userlibs either
Easier to remove the clipboard stuff entirely